### PR TITLE
Add China RVSM altitude mapping

### DIFF
--- a/src/lib/altitude.ts
+++ b/src/lib/altitude.ts
@@ -1,0 +1,60 @@
+const CHINA_RVSM_METERS_BY_FEET = new Map([
+  [2_000, 600],
+  [3_000, 900],
+  [3_900, 1_200],
+  [4_900, 1_500],
+  [5_900, 1_800],
+  [6_900, 2_100],
+  [7_900, 2_400],
+  [8_900, 2_700],
+  [9_800, 3_000],
+  [10_800, 3_300],
+  [11_800, 3_600],
+  [12_800, 3_900],
+  [13_800, 4_200],
+  [14_800, 4_500],
+  [15_700, 4_800],
+  [16_700, 5_100],
+  [17_700, 5_400],
+  [18_700, 5_700],
+  [19_700, 6_000],
+  [20_700, 6_300],
+  [21_700, 6_600],
+  [22_600, 6_900],
+  [23_600, 7_200],
+  [24_600, 7_500],
+  [25_600, 7_800],
+  [26_600, 8_100],
+  [27_600, 8_400],
+  [29_100, 8_900],
+  [30_100, 9_200],
+  [31_100, 9_500],
+  [32_100, 9_800],
+  [33_100, 10_100],
+  [34_100, 10_400],
+  [35_100, 10_700],
+  [36_100, 11_000],
+  [37_100, 11_300],
+  [38_100, 11_600],
+  [39_100, 11_900],
+  [40_100, 12_200],
+  [41_100, 12_500],
+  [43_000, 13_100],
+  [44_900, 13_700],
+  [46_900, 14_300],
+  [48_900, 14_900],
+]);
+
+export const feetToRoundedMeters = (feet: number) => Math.round((feet * 0.3048) / 100) * 100;
+
+export const getCruisingLevelInMeters = (feet: number) => {
+  const chinaRvsmMeters = CHINA_RVSM_METERS_BY_FEET.get(feet);
+
+  return {
+    meters: chinaRvsmMeters ?? feetToRoundedMeters(feet),
+    isChinaRvsm: chinaRvsmMeters !== undefined,
+  };
+};
+
+export const formatCruisingLevelInMeters = (feet: number) =>
+  `${getCruisingLevelInMeters(feet).meters.toLocaleString()} m`;

--- a/src/lib/altitude.unit.test.ts
+++ b/src/lib/altitude.unit.test.ts
@@ -1,0 +1,21 @@
+import { feetToRoundedMeters, formatCruisingLevelInMeters, getCruisingLevelInMeters } from "./altitude";
+import { expect, test } from "vitest";
+
+test("feetToRoundedMeters rounds unmatched cruising levels to the nearest 100 meters", () => {
+  expect(feetToRoundedMeters(30_000)).toBe(9_100);
+});
+
+test("getCruisingLevelInMeters uses the China RVSM table when matched", () => {
+  expect(getCruisingLevelInMeters(29_100)).toEqual({ meters: 8_900, isChinaRvsm: true });
+  expect(getCruisingLevelInMeters(41_100)).toEqual({ meters: 12_500, isChinaRvsm: true });
+  expect(getCruisingLevelInMeters(43_000)).toEqual({ meters: 13_100, isChinaRvsm: true });
+  expect(getCruisingLevelInMeters(44_900)).toEqual({ meters: 13_700, isChinaRvsm: true });
+});
+
+test("getCruisingLevelInMeters falls back to conversion when unmatched", () => {
+  expect(getCruisingLevelInMeters(30_000)).toEqual({ meters: 9_100, isChinaRvsm: false });
+});
+
+test("formatCruisingLevelInMeters formats the metric counterpart", () => {
+  expect(formatCruisingLevelInMeters(29_100)).toBe("8,900 m");
+});

--- a/src/locales/en.po
+++ b/src/locales/en.po
@@ -494,8 +494,8 @@ msgid "Created at"
 msgstr "Created at"
 
 #: src/routes/flights/$callsign.tsx:385
-msgid "Cruising Level (Feet)"
-msgstr "Cruising Level (Feet)"
+msgid "Cruising Level"
+msgstr "Cruising Level"
 
 #: src/routes/flights/$callsign.tsx:137
 msgid "Cruising Level Not Allowed"

--- a/src/locales/zh-cn.po
+++ b/src/locales/zh-cn.po
@@ -494,8 +494,8 @@ msgid "Created at"
 msgstr "创建时间"
 
 #: src/routes/flights/$callsign.tsx:385
-msgid "Cruising Level (Feet)"
-msgstr "巡航高度（英尺）"
+msgid "Cruising Level"
+msgstr "巡航高度"
 
 #: src/routes/flights/$callsign.tsx:137
 msgid "Cruising Level Not Allowed"

--- a/src/routes/flights/$callsign.tsx
+++ b/src/routes/flights/$callsign.tsx
@@ -1,5 +1,6 @@
 import { BackButton } from "@/components/back-button";
 import { FlightWarnings } from "@/components/flight-warnings";
+import { formatCruisingLevelInMeters, getCruisingLevelInMeters } from "@/lib/altitude";
 import { components } from "@/lib/api";
 import { $api } from "@/lib/client";
 import { cn } from "@/lib/utils";
@@ -325,6 +326,23 @@ const Warning: FC<WarningProps & React.ComponentProps<typeof Popover>> = ({
 };
 
 const LEG_IDENTIFIER_DIRECT = "DCT";
+
+const CruisingLevelMeters = ({ feet }: { feet: number }) => {
+  const { t } = useLingui();
+  const { isChinaRvsm } = getCruisingLevelInMeters(feet);
+  const metricAltitude = <span className="text-muted-foreground text-sm">{formatCruisingLevelInMeters(feet)}</span>;
+
+  if (!isChinaRvsm) return metricAltitude;
+
+  return (
+    <Tooltip label={t`China RVSM`}>
+      <span className="text-muted-foreground text-sm underline decoration-dotted underline-offset-2">
+        {formatCruisingLevelInMeters(feet)}
+      </span>
+    </Tooltip>
+  );
+};
+
 function RouteComponent() {
   const { callsign } = Route.useParams();
 
@@ -382,8 +400,13 @@ function RouteComponent() {
             <FplField label={t`Departure`} value={flight.departure} className="col-start-1" />
             {/* <FplField label="Off Block" value="-" /> */}
             {/* <FplField label="Airspeed" value="-" /> */}
-            <FplField label={t`Cruising Level (Feet)`}>
-              {flight.cruising_level && <span className="text-mono">{flight.cruising_level}</span>}
+            <FplField label={t`Cruising Level`}>
+              {flight.cruising_level && (
+                <div className="flex items-baseline gap-2">
+                  <span>{flight.cruising_level} ft</span>
+                  <CruisingLevelMeters feet={flight.cruising_level} />
+                </div>
+              )}
               <Warning flight={flight} warnings={warnings} field="cruising_level" />
             </FplField>
             <FplField label={t`Route`} className="col-span-4">


### PR DESCRIPTION
Fix T-65

## Summary
- Map known China RVSM cruising levels to the exact meter values from the reference table.
- Fall back to feet-to-meter conversion when a level is not in the table.
- Underline table-backed metric values and show a `China RVSM` tooltip in the flight plan UI.
- Keep the cruising level label simplified to `Cruising Level` in both locales.

## Testing
- Added unit coverage for table hits, fallback conversion, and metric formatting.
- Verified the affected UI and locale files remain formatted.