### PR TITLE
Add airport filter to Flights list and i18n placeholder strings

### DIFF
--- a/src/locales/en.po
+++ b/src/locales/en.po
@@ -535,6 +535,10 @@ msgstr "Delivery"
 msgid "Departure"
 msgstr "Departure"
 
+#: src/routes/flights/index.tsx:77
+msgid "Departure or arrival airport"
+msgstr "Departure or arrival airport"
+
 #: src/components/event/event-create.tsx:256
 #: src/components/preferred-route-create.tsx:177
 msgid "Description"

--- a/src/locales/zh-cn.po
+++ b/src/locales/zh-cn.po
@@ -535,6 +535,10 @@ msgstr "放行"
 msgid "Departure"
 msgstr "出发机场"
 
+#: src/routes/flights/index.tsx:77
+msgid "Departure or arrival airport"
+msgstr "出发或到达机场"
+
 #: src/components/event/event-create.tsx:256
 #: src/components/preferred-route-create.tsx:177
 msgid "Description"

--- a/src/routes/flights/index.tsx
+++ b/src/routes/flights/index.tsx
@@ -4,7 +4,7 @@ import { msg } from "@lingui/core/macro";
 import { Trans, useLingui } from "@lingui/react/macro";
 import { Input } from "@mantine/core";
 import { createFileRoute, Link, Outlet } from "@tanstack/react-router";
-import { ChangeEventHandler, useState } from "react";
+import { ChangeEventHandler, useMemo, useState } from "react";
 import * as React from "react";
 
 export const Route = createFileRoute("/flights/")({
@@ -37,24 +37,47 @@ function RouteComponent() {
   const { data: mine } = $api.useQuery("get", "/api/flights/mine");
 
   const [filter, setFilter] = useState("");
+  const [airportFilter, setAirportFilter] = useState("");
+
+  const normalizedFilter = filter.trim().toUpperCase();
+  const normalizedAirportFilter = airportFilter.trim().toUpperCase();
+  const filteredFlights = useMemo(
+    () =>
+      flights?.filter((flight) => {
+        const matchesCallsignOrCid =
+          normalizedFilter === "" ||
+          flight.callsign.toUpperCase().includes(normalizedFilter) ||
+          flight.cid.toUpperCase().includes(normalizedFilter);
+        const matchesAirport =
+          normalizedAirportFilter === "" ||
+          flight.departure.toUpperCase().includes(normalizedAirportFilter) ||
+          flight.arrival.toUpperCase().includes(normalizedAirportFilter);
+
+        return matchesCallsignOrCid && matchesAirport;
+      }),
+    [flights, normalizedAirportFilter, normalizedFilter],
+  );
+
   const onChange: ChangeEventHandler<HTMLInputElement> = (e) => {
     setFilter(e.target.value);
+  };
+  const onAirportFilterChange: ChangeEventHandler<HTMLInputElement> = (e) => {
+    setAirportFilter(e.target.value);
   };
   return (
     <div className="flex flex-col items-start gap-8">
       <h1 className="text-3xl">
         <Trans>Flight Plan Checker</Trans>
       </h1>
-      <div className="flex flex-row gap-4">
+      <div className="flex flex-row flex-wrap gap-4">
         <Input placeholder={t`Callsign`} value={filter} onChange={onChange} />
+        <Input placeholder={t`Departure or arrival airport`} value={airportFilter} onChange={onAirportFilterChange} />
       </div>
       <div className="grid w-full grid-cols-[repeat(auto-fill,_minmax(calc(var(--spacing)*64),_1fr))] gap-x-6 gap-y-4">
         {mine && <Flight flight={mine} />}
-        {flights
-          ?.filter((f) => f.callsign.includes(filter) || f.cid.includes(filter))
-          ?.map((flight) => (
-            <Flight flight={flight} key={flight.callsign} />
-          ))}
+        {filteredFlights?.map((flight) => (
+          <Flight flight={flight} key={flight.callsign} />
+        ))}
         <Outlet />
       </div>
     </div>


### PR DESCRIPTION
### Motivation
- Allow users to filter the flights list by departure or arrival airport to improve searchability on the Flights page.
- Provide localized placeholder text for the new airport filter input in English and Chinese.

### Description
- Added `airportFilter` state, `onAirportFilterChange` handler, and an additional `Input` for airport filtering in `src/routes/flights/index.tsx` and made the input row wrapable.
- Implemented normalized filtering and memoized the filtered list with `useMemo` so flights are filtered by callsign, CID, departure, or arrival.
- Replaced the previous inline filter with the `filteredFlights` mapping and imported `useMemo` from React.
- Added the translation key `Departure or arrival airport` to `src/locales/en.po` and `src/locales/zh-cn.po`.

### Testing
- Ran TypeScript build/type-check which completed successfully.
- Executed the existing automated test suite (`npm test`) and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a008bbe6fe8832d8604dc5c83147c6a)