### PR TITLE
feat: serve ATC positions from uniapi

### DIFF
--- a/src/components/controller-list.tsx
+++ b/src/components/controller-list.tsx
@@ -151,7 +151,6 @@ export const ControllerListTable: React.FC = () => {
         isLoading={isLoading}
         initialState={{ pagination: { pageSize: Number.MAX_SAFE_INTEGER } }}
         hideGlobalSearch
-        stickyHeader
       />
     </div>
   );

--- a/src/components/table.tsx
+++ b/src/components/table.tsx
@@ -1,4 +1,3 @@
-import { cn } from "@/lib/utils";
 import { MessageDescriptor } from "@lingui/core";
 import { Trans, useLingui } from "@lingui/react/macro";
 import { Select, ActionIconGroup, ActionIcon, Table, Skeleton, UnstyledButton, TextInput } from "@mantine/core";
@@ -56,8 +55,6 @@ export interface RichTableProps<TData> {
   initialState?: InitialTableState;
   /** Hide the global free-text search bar, e.g. when a column filter already covers the same search intent. */
   hideGlobalSearch?: boolean;
-  /** Keep the header row visible while the table body scrolls past it. */
-  stickyHeader?: boolean;
 }
 
 const EMPTY_TABLE = [] as never[];
@@ -68,7 +65,6 @@ export const RichTable = <TData,>({
   isLoading,
   initialState,
   hideGlobalSearch,
-  stickyHeader,
 }: RichTableProps<TData>) => {
   const { t, i18n } = useLingui();
 
@@ -104,7 +100,7 @@ export const RichTable = <TData,>({
         <TextInput placeholder={t`Search...`} leftSection={<TbSearch size={16} />} onChange={onGlobalFilterChange} />
       )}
       <Table highlightOnHover>
-        <Table.Thead className={cn(stickyHeader && "sticky !top-[53px] !z-10 bg-[var(--mantine-color-body)]")}>
+        <Table.Thead>
           <Table.Tr>
             {table.getHeaderGroups().map((headerGroup) =>
               headerGroup.headers?.map((header) => (

--- a/src/lib/api.d.ts
+++ b/src/lib/api.d.ts
@@ -196,6 +196,70 @@ export interface paths {
     patch?: never;
     trace?: never;
   };
+  "/api/atc/positions": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get: operations["list_atc_positions"];
+    put?: never;
+    post: operations["create_atc_position"];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/api/atc/positions/audit": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get: operations["list_atc_position_audit_logs"];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/api/atc/positions/{callsign}": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get: operations["get_atc_position"];
+    put: operations["update_atc_position"];
+    post?: never;
+    delete: operations["delete_atc_position"];
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/api/atc/positions/{callsign}/audit": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get: operations["list_atc_position_audit_logs_by_position"];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
   "/api/atc/trainings": {
     parameters: {
       query?: never;
@@ -1170,6 +1234,45 @@ export interface components {
       solo_expires_at?: string | null;
       state: components["schemas"]["UserControllerState"];
     };
+    /** @enum {string} */
+    AtcPositionCategory: "standard" | "chengdu-low-area" | "military" | "atis";
+    AtcPositionDto: {
+      callsign: string;
+      callsign_en?: string | null;
+      callsign_zh?: string | null;
+      category: components["schemas"]["AtcPositionCategory"];
+      cpdlc_code?: string | null;
+      /** Format: date-time */
+      created_at: string;
+      /**
+       * Format: double
+       * @description Radio frequency in MHz.
+       */
+      frequency: number;
+      /**
+       * Format: int32
+       * @description Exact radio frequency in kHz for machine consumers.
+       */
+      frequency_khz: number;
+      is_tier_2: boolean;
+      remarks?: string | null;
+      /** Format: date-time */
+      updated_at: string;
+    };
+    AtcPositionSaveRequest: {
+      callsign: string;
+      callsign_en?: string | null;
+      callsign_zh?: string | null;
+      category: components["schemas"]["AtcPositionCategory"];
+      cpdlc_code?: string | null;
+      /**
+       * Format: double
+       * @description Radio frequency in MHz, for example `118.500`.
+       */
+      frequency: number;
+      is_tier_2: boolean;
+      remarks?: string | null;
+    };
     AtcStatusDto: {
       is_absent: boolean;
       is_visiting: boolean;
@@ -1201,6 +1304,7 @@ export interface components {
     AuditLogEntityKindDto:
       | "event"
       | "atc-application"
+      | "atc-position"
       | "user"
       | "user-role"
       | "user-atc-permission"
@@ -2064,6 +2168,171 @@ export interface operations {
         };
         content: {
           "application/json": components["schemas"]["AtcStatusDto"][];
+        };
+      };
+      500: components["responses"]["InternalServerError"];
+    };
+  };
+  list_atc_positions: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description All published ATC positions and frequencies */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["AtcPositionDto"][];
+        };
+      };
+      500: components["responses"]["InternalServerError"];
+    };
+  };
+  create_atc_position: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody: {
+      content: {
+        "application/json": components["schemas"]["AtcPositionSaveRequest"];
+      };
+    };
+    responses: {
+      /** @description ATC position created */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["AtcPositionDto"];
+        };
+      };
+      500: components["responses"]["InternalServerError"];
+    };
+  };
+  list_atc_position_audit_logs: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description ATC-position audit logs */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["AuditLogDto"][];
+        };
+      };
+      500: components["responses"]["InternalServerError"];
+    };
+  };
+  get_atc_position: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        /** @description ATC callsign */
+        callsign: string;
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description ATC position */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["AtcPositionDto"];
+        };
+      };
+      500: components["responses"]["InternalServerError"];
+    };
+  };
+  update_atc_position: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        /** @description ATC callsign */
+        callsign: string;
+      };
+      cookie?: never;
+    };
+    requestBody: {
+      content: {
+        "application/json": components["schemas"]["AtcPositionSaveRequest"];
+      };
+    };
+    responses: {
+      /** @description ATC position updated */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["AtcPositionDto"];
+        };
+      };
+      500: components["responses"]["InternalServerError"];
+    };
+  };
+  delete_atc_position: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        /** @description ATC callsign */
+        callsign: string;
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description ATC position deleted */
+      204: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content?: never;
+      };
+      500: components["responses"]["InternalServerError"];
+    };
+  };
+  list_atc_position_audit_logs_by_position: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        /** @description ATC callsign */
+        callsign: string;
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description Audit logs for an ATC position */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["AuditLogDto"][];
         };
       };
       500: components["responses"]["InternalServerError"];

--- a/src/locales/en.po
+++ b/src/locales/en.po
@@ -290,9 +290,23 @@ msgstr "ATC Center"
 msgid "ATC Permission"
 msgstr "ATC Permission"
 
+#: src/routes/_doc/airspace/station.tsx:32
+msgid "ATC Position"
+msgstr "ATC Position"
+
 #: src/components/app/app-nav-menu.tsx:62
 msgid "ATC Positions & Frequencies"
 msgstr "ATC Positions & Frequencies"
+
+#: src/routes/_doc/airspace/station.tsx:84
+#: src/routes/_doc/airspace/station.tsx:100
+msgid "ATC Positions and Frequencies"
+msgstr "ATC Positions and Frequencies"
+
+#: src/routes/_doc/airspace/station.tsx:19
+#: src/routes/_doc/airspace/station.tsx:26
+msgid "ATIS"
+msgstr "ATIS"
 
 #: src/routes/controllers/applications/$id.tsx:64
 #: src/routes/events/$id.tsx:69
@@ -325,14 +339,14 @@ msgstr "Basic Information"
 msgid "Become a Controller"
 msgstr "Become a Controller"
 
-#: src/components/controller-center/my-atc-bookings.tsx:153
+#: src/components/controller-center/my-atc-bookings.tsx:154
 #: src/components/event/atc-slot-list.tsx:170
 #: src/components/event/slot-list.tsx:138
 msgid "Book"
 msgstr "Book"
 
-#: src/components/controller-center/my-atc-bookings.tsx:90
-#: src/components/controller-center/my-atc-bookings.tsx:93
+#: src/components/controller-center/my-atc-bookings.tsx:91
+#: src/components/controller-center/my-atc-bookings.tsx:94
 msgid "Book ATC Position"
 msgstr "Book ATC Position"
 
@@ -366,7 +380,7 @@ msgstr "C1"
 msgid "C3"
 msgstr "C3"
 
-#: src/components/controller-center/my-atc-bookings.tsx:103
+#: src/components/controller-center/my-atc-bookings.tsx:104
 #: src/components/event/atc-slot-create.tsx:104
 #: src/components/event/atc-slot-list.tsx:36
 #: src/components/event/slot-import.tsx:157
@@ -379,17 +393,17 @@ msgstr "Callsign"
 msgid "Callsign & Aircraft"
 msgstr "Callsign & Aircraft"
 
-#: src/components/controller-center/my-atc-bookings.tsx:65
+#: src/components/controller-center/my-atc-bookings.tsx:66
 msgid "Callsign is required"
 msgstr "Callsign is required"
 
 #: src/components/app/assume-role-modal.tsx:41
-#: src/components/controller-center/my-atc-bookings.tsx:184
+#: src/components/controller-center/my-atc-bookings.tsx:182
 #: src/routes/users/index.tsx:96
 msgid "Cancel"
 msgstr "Cancel"
 
-#: src/components/controller-center/my-atc-bookings.tsx:170
+#: src/components/controller-center/my-atc-bookings.tsx:174
 msgid "Cancel the booking for {callsign}?"
 msgstr "Cancel the booking for {callsign}?"
 
@@ -402,6 +416,10 @@ msgstr "Cancel Training"
 #: src/components/atc-training/training-list.tsx:53
 msgid "Cancelled"
 msgstr "Cancelled"
+
+#: src/routes/_doc/airspace/station.tsx:37
+msgid "Category"
+msgstr "Category"
 
 #: src/components/atc-permission-modal.tsx:28
 msgid "Center"
@@ -423,6 +441,11 @@ msgstr "Check at VATSIM"
 msgid "Checklist"
 msgstr "Checklist"
 
+#: src/routes/_doc/airspace/station.tsx:17
+#: src/routes/_doc/airspace/station.tsx:24
+msgid "Chengdu Low Area"
+msgstr "Chengdu Low Area"
+
 #: src/components/audit-log/audit-log-table.tsx:141
 msgid "Child Entity"
 msgstr "Child Entity"
@@ -443,6 +466,10 @@ msgstr "China RVSM flight level"
 #: src/routes/flights/$callsign.tsx:103
 msgid "China RVSM odd flight level"
 msgstr "China RVSM odd flight level"
+
+#: src/routes/_doc/airspace/station.tsx:55
+msgid "Chinese Callsign"
+msgstr "Chinese Callsign"
 
 #: src/routes/sheets/$id.tsx:352
 msgid "Chinese description"
@@ -539,6 +566,10 @@ msgstr "Controlling"
 #: src/components/controller-center/quarterly-controlling-time.tsx:16
 msgid "Controlling History"
 msgstr "Controlling History"
+
+#: src/routes/_doc/airspace/station.tsx:108
+msgid "CPDLC availability is decided by the controller. It is used at or above 7,800 meters; refer to the controller's ATC information."
+msgstr "CPDLC availability is decided by the controller. It is used at or above 7,800 meters; refer to the controller's ATC information."
 
 #: src/components/atc-training/training-application-create.tsx:201
 #: src/components/atc-training/training-save.tsx:151
@@ -661,12 +692,12 @@ msgstr "Drag CSV here or click to select files"
 #: src/components/atc-application/atc-application-form.tsx:148
 #: src/components/atc-training/training-application-create.tsx:105
 #: src/components/atc-training/training-save.tsx:75
-#: src/components/controller-center/my-atc-bookings.tsx:86
+#: src/components/controller-center/my-atc-bookings.tsx:87
 #: src/components/event/atc-slot-create.tsx:86
 msgid "Edit"
 msgstr "Edit"
 
-#: src/components/controller-center/my-atc-bookings.tsx:93
+#: src/components/controller-center/my-atc-bookings.tsx:94
 msgid "Edit ATC Booking"
 msgstr "Edit ATC Booking"
 
@@ -716,7 +747,7 @@ msgstr "Email"
 #: src/components/atc-training/training-application-create.tsx:183
 #: src/components/atc-training/training-list.tsx:32
 #: src/components/atc-training/training-save.tsx:141
-#: src/components/controller-center/my-atc-bookings.tsx:129
+#: src/components/controller-center/my-atc-bookings.tsx:130
 #: src/components/event/atc-slot-create.tsx:127
 #: src/components/event/atc-slot-list.tsx:50
 #: src/components/event/event-create.tsx:180
@@ -733,15 +764,19 @@ msgid "End booking time must be after start booking time"
 msgstr "End booking time must be after start booking time"
 
 #: src/components/atc-training/training-application-create.tsx:81
-#: src/components/controller-center/my-atc-bookings.tsx:67
+#: src/components/controller-center/my-atc-bookings.tsx:68
 msgid "End time is required"
 msgstr "End time is required"
 
 #: src/components/atc-training/training-application-create.tsx:84
-#: src/components/controller-center/my-atc-bookings.tsx:69
+#: src/components/controller-center/my-atc-bookings.tsx:70
 #: src/components/event/event-create.tsx:96
 msgid "End time must be after start time"
 msgstr "End time must be after start time"
+
+#: src/routes/_doc/airspace/station.tsx:60
+msgid "English Callsign"
+msgstr "English Callsign"
 
 #: src/routes/sheets/$id.tsx:364
 msgid "English description"
@@ -777,7 +812,7 @@ msgstr "even flight level"
 #: src/components/app/app-nav-menu.tsx:105
 #: src/components/app/app-nav-menu.tsx:117
 #: src/components/audit-log/audit-log-table.tsx:15
-#: src/components/controller-center/my-atc-bookings.tsx:229
+#: src/components/controller-center/my-atc-bookings.tsx:227
 msgid "Event"
 msgstr "Event"
 
@@ -830,6 +865,10 @@ msgstr "Failed to import slots."
 #: src/components/homepage/notam-board.tsx:87
 msgid "Failed to load announcements."
 msgstr "Failed to load announcements."
+
+#: src/routes/_doc/airspace/station.tsx:115
+msgid "Failed to load ATC positions"
+msgstr "Failed to load ATC positions"
 
 #: src/components/audit-log/audit-log-table.tsx:163
 msgid "Failed to load audit logs"
@@ -946,6 +985,10 @@ msgstr "For technical limitations, the boundaries shown on the map may be outdat
 #: src/routes/index.tsx:51
 msgid "Forum"
 msgstr "Forum"
+
+#: src/routes/_doc/airspace/station.tsx:66
+msgid "Frequency"
+msgstr "Frequency"
 
 #: src/routes/users/me.tsx:56
 msgid "Full name"
@@ -1172,6 +1215,11 @@ msgstr "metric flight level (meters)"
 msgid "metric odd flight level (meters)"
 msgstr "metric odd flight level (meters)"
 
+#: src/routes/_doc/airspace/station.tsx:18
+#: src/routes/_doc/airspace/station.tsx:25
+msgid "Military"
+msgstr "Military"
+
 #: src/components/event/atc-slot-create.tsx:153
 msgid "Minimum State"
 msgstr "Minimum State"
@@ -1193,7 +1241,7 @@ msgstr "My account belongs to VATPRC division."
 msgid "My Application"
 msgstr "My Application"
 
-#: src/components/controller-center/my-atc-bookings.tsx:199
+#: src/components/controller-center/my-atc-bookings.tsx:197
 msgid "My ATC Bookings"
 msgstr "My ATC Bookings"
 
@@ -1493,7 +1541,8 @@ msgstr "Release"
 msgid "Remark"
 msgstr "Remark"
 
-#: src/components/controller-center/my-atc-bookings.tsx:142
+#: src/components/controller-center/my-atc-bookings.tsx:143
+#: src/routes/_doc/airspace/station.tsx:76
 msgid "Remarks"
 msgstr "Remarks"
 
@@ -1567,7 +1616,7 @@ msgstr "S3"
 #: src/components/atc-permission-modal.tsx:220
 #: src/components/atc-training/training-application-create.tsx:201
 #: src/components/atc-training/training-save.tsx:151
-#: src/components/controller-center/my-atc-bookings.tsx:153
+#: src/components/controller-center/my-atc-bookings.tsx:154
 #: src/components/event/atc-slot-create.tsx:177
 #: src/components/event/event-create.tsx:284
 #: src/components/preferred-route-create.tsx:202
@@ -1583,6 +1632,10 @@ msgstr "Save changes"
 #: src/routes/sheets/$id.tsx:408
 msgid "Save sheet"
 msgstr "Save sheet"
+
+#: src/routes/_doc/airspace/station.tsx:103
+msgid "Search by position, callsign, frequency, category, or CPDLC code."
+msgstr "Search by position, callsign, frequency, category, or CPDLC code."
 
 #: src/components/table.tsx:104
 msgid "Search..."
@@ -1677,6 +1730,11 @@ msgstr "Staff"
 msgid "Staff review"
 msgstr "Staff review"
 
+#: src/routes/_doc/airspace/station.tsx:16
+#: src/routes/_doc/airspace/station.tsx:23
+msgid "Standard"
+msgstr "Standard"
+
 #: src/components/app/app-nav-menu.tsx:63
 #: src/components/controller-center/resource-grid.tsx:40
 #: src/routes/_doc/airspace/sop.tsx:14
@@ -1691,7 +1749,7 @@ msgstr "Start and End booking time must be both set or unset"
 #: src/components/atc-training/training-application-create.tsx:172
 #: src/components/atc-training/training-list.tsx:28
 #: src/components/atc-training/training-save.tsx:130
-#: src/components/controller-center/my-atc-bookings.tsx:117
+#: src/components/controller-center/my-atc-bookings.tsx:118
 #: src/components/event/atc-slot-create.tsx:116
 #: src/components/event/atc-slot-list.tsx:39
 #: src/components/event/event-create.tsx:168
@@ -1712,7 +1770,7 @@ msgid "Start immediately"
 msgstr "Start immediately"
 
 #: src/components/atc-training/training-application-create.tsx:78
-#: src/components/controller-center/my-atc-bookings.tsx:66
+#: src/components/controller-center/my-atc-bookings.tsx:67
 msgid "Start time is required"
 msgstr "Start time is required"
 
@@ -1918,6 +1976,7 @@ msgid "This page is not available in English."
 msgstr "This page is not available in English."
 
 #: src/components/atc-permission-modal.tsx:26
+#: src/routes/_doc/airspace/station.tsx:43
 msgid "Tier 2"
 msgstr "Tier 2"
 
@@ -2178,6 +2237,7 @@ msgstr "Withdraw"
 msgid "Write your transponder equipment code."
 msgstr "Write your transponder equipment code."
 
+#: src/routes/_doc/airspace/station.tsx:47
 #: src/routes/users/me.tsx:84
 #: src/routes/users/me.tsx:85
 msgid "Yes"
@@ -2187,7 +2247,7 @@ msgstr "Yes"
 msgid "You have no training sessions yet. Apply for a training to get started."
 msgstr "You have no training sessions yet. Apply for a training to get started."
 
-#: src/components/controller-center/my-atc-bookings.tsx:211
+#: src/components/controller-center/my-atc-bookings.tsx:209
 msgid "You have no upcoming ATC bookings."
 msgstr "You have no upcoming ATC bookings."
 

--- a/src/locales/zh-cn.po
+++ b/src/locales/zh-cn.po
@@ -290,9 +290,23 @@ msgstr "ATC 中心"
 msgid "ATC Permission"
 msgstr "管制员权限"
 
+#: src/routes/_doc/airspace/station.tsx:32
+msgid "ATC Position"
+msgstr "管制席位"
+
 #: src/components/app/app-nav-menu.tsx:62
 msgid "ATC Positions & Frequencies"
 msgstr "管制席位及频率"
+
+#: src/routes/_doc/airspace/station.tsx:84
+#: src/routes/_doc/airspace/station.tsx:100
+msgid "ATC Positions and Frequencies"
+msgstr "管制席位及频率"
+
+#: src/routes/_doc/airspace/station.tsx:19
+#: src/routes/_doc/airspace/station.tsx:26
+msgid "ATIS"
+msgstr "自动终端情报服务（ATIS）"
 
 #: src/routes/controllers/applications/$id.tsx:64
 #: src/routes/events/$id.tsx:69
@@ -325,14 +339,14 @@ msgstr "基本信息"
 msgid "Become a Controller"
 msgstr "成为管制员"
 
-#: src/components/controller-center/my-atc-bookings.tsx:153
+#: src/components/controller-center/my-atc-bookings.tsx:154
 #: src/components/event/atc-slot-list.tsx:170
 #: src/components/event/slot-list.tsx:138
 msgid "Book"
 msgstr "预订"
 
-#: src/components/controller-center/my-atc-bookings.tsx:90
-#: src/components/controller-center/my-atc-bookings.tsx:93
+#: src/components/controller-center/my-atc-bookings.tsx:91
+#: src/components/controller-center/my-atc-bookings.tsx:94
 msgid "Book ATC Position"
 msgstr "预约管制席位"
 
@@ -366,7 +380,7 @@ msgstr "C1"
 msgid "C3"
 msgstr "C3"
 
-#: src/components/controller-center/my-atc-bookings.tsx:103
+#: src/components/controller-center/my-atc-bookings.tsx:104
 #: src/components/event/atc-slot-create.tsx:104
 #: src/components/event/atc-slot-list.tsx:36
 #: src/components/event/slot-import.tsx:157
@@ -379,17 +393,17 @@ msgstr "呼号"
 msgid "Callsign & Aircraft"
 msgstr "呼号和机型"
 
-#: src/components/controller-center/my-atc-bookings.tsx:65
+#: src/components/controller-center/my-atc-bookings.tsx:66
 msgid "Callsign is required"
 msgstr "必须填写席位呼号"
 
 #: src/components/app/assume-role-modal.tsx:41
-#: src/components/controller-center/my-atc-bookings.tsx:184
+#: src/components/controller-center/my-atc-bookings.tsx:182
 #: src/routes/users/index.tsx:96
 msgid "Cancel"
 msgstr "取消"
 
-#: src/components/controller-center/my-atc-bookings.tsx:170
+#: src/components/controller-center/my-atc-bookings.tsx:174
 msgid "Cancel the booking for {callsign}?"
 msgstr "确定取消 {callsign} 的预约吗？"
 
@@ -402,6 +416,10 @@ msgstr "取消训练"
 #: src/components/atc-training/training-list.tsx:53
 msgid "Cancelled"
 msgstr "已取消"
+
+#: src/routes/_doc/airspace/station.tsx:37
+msgid "Category"
+msgstr "类别"
 
 #: src/components/atc-permission-modal.tsx:28
 msgid "Center"
@@ -423,6 +441,11 @@ msgstr "去 VATSIM 确认"
 msgid "Checklist"
 msgstr "检查单"
 
+#: src/routes/_doc/airspace/station.tsx:17
+#: src/routes/_doc/airspace/station.tsx:24
+msgid "Chengdu Low Area"
+msgstr "成都低空"
+
 #: src/components/audit-log/audit-log-table.tsx:141
 msgid "Child Entity"
 msgstr "子实体"
@@ -443,6 +466,10 @@ msgstr "中国 RVSM 高度层"
 #: src/routes/flights/$callsign.tsx:103
 msgid "China RVSM odd flight level"
 msgstr "中国 RVSM 单数高度层"
+
+#: src/routes/_doc/airspace/station.tsx:55
+msgid "Chinese Callsign"
+msgstr "中文呼号"
 
 #: src/routes/sheets/$id.tsx:352
 msgid "Chinese description"
@@ -539,6 +566,10 @@ msgstr "管制"
 #: src/components/controller-center/quarterly-controlling-time.tsx:16
 msgid "Controlling History"
 msgstr "管制上线记录"
+
+#: src/routes/_doc/airspace/station.tsx:108
+msgid "CPDLC availability is decided by the controller. It is used at or above 7,800 meters; refer to the controller's ATC information."
+msgstr "是否提供 CPDLC 服务由管制员决定。CPDLC 适用于 7,800 米及以上高度，具体请参阅管制员发布的管制信息。"
 
 #: src/components/atc-training/training-application-create.tsx:201
 #: src/components/atc-training/training-save.tsx:151
@@ -661,12 +692,12 @@ msgstr "在此处拖放 CSV 文件或者点击此处选择文件"
 #: src/components/atc-application/atc-application-form.tsx:148
 #: src/components/atc-training/training-application-create.tsx:105
 #: src/components/atc-training/training-save.tsx:75
-#: src/components/controller-center/my-atc-bookings.tsx:86
+#: src/components/controller-center/my-atc-bookings.tsx:87
 #: src/components/event/atc-slot-create.tsx:86
 msgid "Edit"
 msgstr "编辑"
 
-#: src/components/controller-center/my-atc-bookings.tsx:93
+#: src/components/controller-center/my-atc-bookings.tsx:94
 msgid "Edit ATC Booking"
 msgstr "编辑管制席位预约"
 
@@ -716,7 +747,7 @@ msgstr "电子邮箱"
 #: src/components/atc-training/training-application-create.tsx:183
 #: src/components/atc-training/training-list.tsx:32
 #: src/components/atc-training/training-save.tsx:141
-#: src/components/controller-center/my-atc-bookings.tsx:129
+#: src/components/controller-center/my-atc-bookings.tsx:130
 #: src/components/event/atc-slot-create.tsx:127
 #: src/components/event/atc-slot-list.tsx:50
 #: src/components/event/event-create.tsx:180
@@ -733,15 +764,19 @@ msgid "End booking time must be after start booking time"
 msgstr "预订结束时间必须晚于开始预订时间"
 
 #: src/components/atc-training/training-application-create.tsx:81
-#: src/components/controller-center/my-atc-bookings.tsx:67
+#: src/components/controller-center/my-atc-bookings.tsx:68
 msgid "End time is required"
 msgstr "结束时间为必填项"
 
 #: src/components/atc-training/training-application-create.tsx:84
-#: src/components/controller-center/my-atc-bookings.tsx:69
+#: src/components/controller-center/my-atc-bookings.tsx:70
 #: src/components/event/event-create.tsx:96
 msgid "End time must be after start time"
 msgstr "结束时间必须晚于开始时间"
+
+#: src/routes/_doc/airspace/station.tsx:60
+msgid "English Callsign"
+msgstr "英文呼号"
 
 #: src/routes/sheets/$id.tsx:364
 msgid "English description"
@@ -777,7 +812,7 @@ msgstr "英制双数飞行高度层"
 #: src/components/app/app-nav-menu.tsx:105
 #: src/components/app/app-nav-menu.tsx:117
 #: src/components/audit-log/audit-log-table.tsx:15
-#: src/components/controller-center/my-atc-bookings.tsx:229
+#: src/components/controller-center/my-atc-bookings.tsx:227
 msgid "Event"
 msgstr "活动"
 
@@ -830,6 +865,10 @@ msgstr "无法导入时刻。"
 #: src/components/homepage/notam-board.tsx:87
 msgid "Failed to load announcements."
 msgstr "无法加载公告。"
+
+#: src/routes/_doc/airspace/station.tsx:115
+msgid "Failed to load ATC positions"
+msgstr "无法加载管制席位"
 
 #: src/components/audit-log/audit-log-table.tsx:163
 msgid "Failed to load audit logs"
@@ -946,6 +985,10 @@ msgstr "由于技术限制，地图上显示的边界可能过时或者被简化
 #: src/routes/index.tsx:51
 msgid "Forum"
 msgstr "论坛"
+
+#: src/routes/_doc/airspace/station.tsx:66
+msgid "Frequency"
+msgstr "频率"
 
 #: src/routes/users/me.tsx:56
 msgid "Full name"
@@ -1172,6 +1215,11 @@ msgstr "公制飞行高度层"
 msgid "metric odd flight level (meters)"
 msgstr "公制单数飞行高度层（米）"
 
+#: src/routes/_doc/airspace/station.tsx:18
+#: src/routes/_doc/airspace/station.tsx:25
+msgid "Military"
+msgstr "军用"
+
 #: src/components/event/atc-slot-create.tsx:153
 msgid "Minimum State"
 msgstr "最低权限"
@@ -1193,7 +1241,7 @@ msgstr "我的 VATSIM 账号属于 VATPRC 分部。"
 msgid "My Application"
 msgstr "我的申请"
 
-#: src/components/controller-center/my-atc-bookings.tsx:199
+#: src/components/controller-center/my-atc-bookings.tsx:197
 msgid "My ATC Bookings"
 msgstr "我的管制席位预约"
 
@@ -1493,7 +1541,8 @@ msgstr "取消预订"
 msgid "Remark"
 msgstr "备注"
 
-#: src/components/controller-center/my-atc-bookings.tsx:142
+#: src/components/controller-center/my-atc-bookings.tsx:143
+#: src/routes/_doc/airspace/station.tsx:76
 msgid "Remarks"
 msgstr "备注"
 
@@ -1567,7 +1616,7 @@ msgstr "S3"
 #: src/components/atc-permission-modal.tsx:220
 #: src/components/atc-training/training-application-create.tsx:201
 #: src/components/atc-training/training-save.tsx:151
-#: src/components/controller-center/my-atc-bookings.tsx:153
+#: src/components/controller-center/my-atc-bookings.tsx:154
 #: src/components/event/atc-slot-create.tsx:177
 #: src/components/event/event-create.tsx:284
 #: src/components/preferred-route-create.tsx:202
@@ -1583,6 +1632,10 @@ msgstr "保存变更"
 #: src/routes/sheets/$id.tsx:408
 msgid "Save sheet"
 msgstr "保存表单"
+
+#: src/routes/_doc/airspace/station.tsx:103
+msgid "Search by position, callsign, frequency, category, or CPDLC code."
+msgstr "可按席位、呼号、频率、类别或 CPDLC 代码搜索。"
 
 #: src/components/table.tsx:104
 msgid "Search..."
@@ -1677,6 +1730,11 @@ msgstr "职员"
 msgid "Staff review"
 msgstr "审核"
 
+#: src/routes/_doc/airspace/station.tsx:16
+#: src/routes/_doc/airspace/station.tsx:23
+msgid "Standard"
+msgstr "常规"
+
 #: src/components/app/app-nav-menu.tsx:63
 #: src/components/controller-center/resource-grid.tsx:40
 #: src/routes/_doc/airspace/sop.tsx:14
@@ -1691,7 +1749,7 @@ msgstr "开始和结束预订时间必须同时设置或同时不设置"
 #: src/components/atc-training/training-application-create.tsx:172
 #: src/components/atc-training/training-list.tsx:28
 #: src/components/atc-training/training-save.tsx:130
-#: src/components/controller-center/my-atc-bookings.tsx:117
+#: src/components/controller-center/my-atc-bookings.tsx:118
 #: src/components/event/atc-slot-create.tsx:116
 #: src/components/event/atc-slot-list.tsx:39
 #: src/components/event/event-create.tsx:168
@@ -1712,7 +1770,7 @@ msgid "Start immediately"
 msgstr "立即开始"
 
 #: src/components/atc-training/training-application-create.tsx:78
-#: src/components/controller-center/my-atc-bookings.tsx:66
+#: src/components/controller-center/my-atc-bookings.tsx:67
 msgid "Start time is required"
 msgstr "开始时间为必填项"
 
@@ -1918,6 +1976,7 @@ msgid "This page is not available in English."
 msgstr "本页面仅支持简体中文。"
 
 #: src/components/atc-permission-modal.tsx:26
+#: src/routes/_doc/airspace/station.tsx:43
 msgid "Tier 2"
 msgstr "Tier 2"
 
@@ -2178,6 +2237,7 @@ msgstr "撤回"
 msgid "Write your transponder equipment code."
 msgstr "给出你的应答机设备代码。"
 
+#: src/routes/_doc/airspace/station.tsx:47
 #: src/routes/users/me.tsx:84
 #: src/routes/users/me.tsx:85
 msgid "Yes"
@@ -2187,7 +2247,7 @@ msgstr "是"
 msgid "You have no training sessions yet. Apply for a training to get started."
 msgstr "你还没有训练记录，报名一次训练开始你的进阶之旅。"
 
-#: src/components/controller-center/my-atc-bookings.tsx:211
+#: src/components/controller-center/my-atc-bookings.tsx:209
 msgid "You have no upcoming ATC bookings."
 msgstr "您没有即将开始的管制席位预约。"
 

--- a/src/routes/_doc/airspace/station.tsx
+++ b/src/routes/_doc/airspace/station.tsx
@@ -1,6 +1,131 @@
-import { createDiscourseFileRoute } from "@/components/doc/discourse-doc";
+import { RichTable } from "@/components/table";
+import { components } from "@/lib/api";
+import { $api } from "@/lib/client";
+import type { MessageDescriptor } from "@lingui/core";
+import { msg } from "@lingui/core/macro";
+import { useLingui } from "@lingui/react";
+import { Trans } from "@lingui/react/macro";
+import { Alert, Badge } from "@mantine/core";
 import { createFileRoute } from "@tanstack/react-router";
+import { ColumnDef } from "@tanstack/react-table";
 
-export const Route = createFileRoute("/_doc/airspace/station")(
-  createDiscourseFileRoute("/_doc/airspace/station", "8884", "8884"),
-);
+type AtcPosition = components["schemas"]["AtcPositionDto"];
+type AtcPositionCategory = components["schemas"]["AtcPositionCategory"];
+
+const CATEGORY_LABELS: Record<AtcPositionCategory, MessageDescriptor> = {
+  standard: msg`Standard`,
+  "chengdu-low-area": msg`Chengdu Low Area`,
+  military: msg`Military`,
+  atis: msg`ATIS`,
+};
+
+const CATEGORY_FILTERS: { value: AtcPositionCategory; label: MessageDescriptor }[] = [
+  { value: "standard", label: msg`Standard` },
+  { value: "chengdu-low-area", label: msg`Chengdu Low Area` },
+  { value: "military", label: msg`Military` },
+  { value: "atis", label: msg`ATIS` },
+];
+
+const columns: ColumnDef<AtcPosition>[] = [
+  {
+    accessorKey: "callsign",
+    header: () => <Trans>ATC Position</Trans>,
+    cell: ({ getValue }) => <code className="whitespace-nowrap">{getValue<string>()}</code>,
+  },
+  {
+    accessorKey: "category",
+    header: () => <Trans>Category</Trans>,
+    cell: ({ getValue }) => <CategoryLabel category={getValue<AtcPositionCategory>()} />,
+    meta: { filterValues: CATEGORY_FILTERS },
+  },
+  {
+    accessorKey: "is_tier_2",
+    header: () => <Trans>Tier 2</Trans>,
+    cell: ({ getValue }) =>
+      getValue<boolean>() ? (
+        <Badge color="green" variant="light">
+          <Trans>Yes</Trans>
+        </Badge>
+      ) : null,
+    enableGlobalFilter: false,
+    enableColumnFilter: false,
+  },
+  {
+    accessorKey: "callsign_zh",
+    header: () => <Trans>Chinese Callsign</Trans>,
+    cell: ({ getValue }) => getValue<string | null>() ?? "—",
+  },
+  {
+    accessorKey: "callsign_en",
+    header: () => <Trans>English Callsign</Trans>,
+    cell: ({ getValue }) => getValue<string | null>() ?? "—",
+  },
+  {
+    id: "frequency",
+    accessorFn: (position) => (position.frequency_khz / 1000).toFixed(3),
+    header: () => <Trans>Frequency</Trans>,
+    cell: ({ getValue }) => <code>{getValue<string>()}</code>,
+  },
+  {
+    accessorKey: "cpdlc_code",
+    header: () => "CPDLC (S0780+)",
+    cell: ({ getValue }) => getValue<string | null>() ?? "—",
+  },
+  {
+    accessorKey: "remarks",
+    header: () => <Trans>Remarks</Trans>,
+    cell: ({ getValue }) => getValue<string | null>() ?? "—",
+  },
+];
+
+export const Route = createFileRoute("/_doc/airspace/station")({
+  component: RouteComponent,
+  head: (ctx) => ({
+    meta: [{ title: ctx.match.context.i18n._(msg`ATC Positions and Frequencies`) }],
+  }),
+});
+
+function CategoryLabel({ category }: { category: AtcPositionCategory }) {
+  const { i18n } = useLingui();
+  return i18n._(CATEGORY_LABELS[category]);
+}
+
+function RouteComponent() {
+  const { data, error, isLoading } = $api.useQuery("get", "/api/atc/positions");
+
+  return (
+    <main className="container mx-auto flex flex-col gap-4">
+      <div>
+        <h1 className="text-3xl">
+          <Trans>ATC Positions and Frequencies</Trans>
+        </h1>
+        <p className="text-gray-600 dark:text-gray-400">
+          <Trans>Search by position, callsign, frequency, category, or CPDLC code.</Trans>
+        </p>
+      </div>
+
+      <Alert color="blue">
+        <Trans>
+          CPDLC availability is decided by the controller. It is used at or above 7,800 meters; refer to the
+          controller&apos;s ATC information.
+        </Trans>
+      </Alert>
+
+      {error && (
+        <Alert color="red" title={<Trans>Failed to load ATC positions</Trans>}>
+          {error.detail}
+        </Alert>
+      )}
+
+      <div className="overflow-x-auto">
+        <RichTable
+          data={data}
+          columns={columns}
+          isLoading={isLoading}
+          stickyHeader
+          initialState={{ pagination: { pageIndex: 0, pageSize: 50 } }}
+        />
+      </div>
+    </main>
+  );
+}

--- a/src/routes/_doc/airspace/station.tsx
+++ b/src/routes/_doc/airspace/station.tsx
@@ -30,25 +30,22 @@ const columns: ColumnDef<AtcPosition>[] = [
   {
     accessorKey: "callsign",
     header: () => <Trans>ATC Position</Trans>,
-    cell: ({ getValue }) => <code className="whitespace-nowrap">{getValue<string>()}</code>,
+    cell: ({ getValue, row }) => (
+      <span className="flex flex-row gap-1">
+        <code className="whitespace-nowrap">{getValue<string>()}</code>
+        {row.original.is_tier_2 && (
+          <Badge color="green" variant="outline">
+            <Trans>Tier 2</Trans>
+          </Badge>
+        )}
+      </span>
+    ),
   },
   {
     accessorKey: "category",
     header: () => <Trans>Category</Trans>,
     cell: ({ getValue }) => <CategoryLabel category={getValue<AtcPositionCategory>()} />,
     meta: { filterValues: CATEGORY_FILTERS },
-  },
-  {
-    accessorKey: "is_tier_2",
-    header: () => <Trans>Tier 2</Trans>,
-    cell: ({ getValue }) =>
-      getValue<boolean>() ? (
-        <Badge color="green" variant="light">
-          <Trans>Yes</Trans>
-        </Badge>
-      ) : null,
-    enableGlobalFilter: false,
-    enableColumnFilter: false,
   },
   {
     accessorKey: "callsign_zh",
@@ -95,14 +92,9 @@ function RouteComponent() {
 
   return (
     <main className="container mx-auto flex flex-col gap-4">
-      <div>
-        <h1 className="text-3xl">
-          <Trans>ATC Positions and Frequencies</Trans>
-        </h1>
-        <p className="text-gray-600 dark:text-gray-400">
-          <Trans>Search by position, callsign, frequency, category, or CPDLC code.</Trans>
-        </p>
-      </div>
+      <h1 className="text-3xl">
+        <Trans>ATC Positions and Frequencies</Trans>
+      </h1>
 
       <Alert color="blue">
         <Trans>
@@ -117,15 +109,13 @@ function RouteComponent() {
         </Alert>
       )}
 
-      <div className="overflow-x-auto">
-        <RichTable
-          data={data}
-          columns={columns}
-          isLoading={isLoading}
-          stickyHeader
-          initialState={{ pagination: { pageIndex: 0, pageSize: 50 } }}
-        />
-      </div>
+      <RichTable
+        data={data}
+        columns={columns}
+        isLoading={isLoading}
+        initialState={{ pagination: { pageIndex: 0, pageSize: 50 } }}
+        hideGlobalSearch
+      />
     </main>
   );
 }


### PR DESCRIPTION
## Summary

- replace the Discourse-backed station page with the uniapi ATC-position endpoint
- add searchable and filterable position, frequency, category, Tier 2, CPDLC, and remarks columns

## Testing

<img width="1560" height="1080" alt="image" src="https://github.com/user-attachments/assets/9a7ed4a4-7a95-4293-9879-7c22d32d2a02" />



## Dependency

- Depends on [VATPRChina/uniapi#3](https://github.com/VATPRChina/uniapi/pull/3)

## Tracking

- [T-85 提供API管理管制席位](https://linear.app/vatprc/issue/T-85/%E6%8F%90%E4%BE%9Bapi%E7%AE%A1%E7%90%86%E7%AE%A1%E5%88%B6%E5%B8%AD%E4%BD%8D)